### PR TITLE
Upgrade to Node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20.11.1
       - name: Install deps and build dist
         run: npm i
 

--- a/.github/workflows/run-cache-result-action.yml
+++ b/.github/workflows/run-cache-result-action.yml
@@ -9,10 +9,10 @@ jobs:
       optional-result: ${{ steps.restore-secondary-cache.outputs.result }}
     steps:
       - id: restore-cache
-        uses: parallel-markets/cache-result-action@f6b4cbf83108f6b777dfc78925e71da352189d05
+        uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
 
       - id: restore-secondary-cache
-        uses: parallel-markets/cache-result-action@f6b4cbf83108f6b777dfc78925e71da352189d05
+        uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
         with:
           cache-group: optional
 
@@ -20,7 +20,7 @@ jobs:
     needs: check-sha-result
     runs-on: ubuntu-latest
     steps:
-      - uses: parallel-markets/cache-result-action@f6b4cbf83108f6b777dfc78925e71da352189d05
+      - uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
         with:
           result: success
 
@@ -28,7 +28,7 @@ jobs:
     needs: check-sha-result
     runs-on: ubuntu-latest
     steps:
-      - uses: parallel-markets/cache-result-action@f6b4cbf83108f6b777dfc78925e71da352189d05
+      - uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
         with:
           result: success
           cache-group: optional

--- a/.github/workflows/run-cache-result-action.yml
+++ b/.github/workflows/run-cache-result-action.yml
@@ -5,7 +5,7 @@ on: push
 # that a change is valid before merging.
 
 # To update edge to the current commit, use:
-# $ git tag -f edge HEAD; git push -f origin edge
+# $ git tag -f edge HEAD && git push -f origin edge
 
 jobs:
   check-sha-result:

--- a/.github/workflows/run-cache-result-action.yml
+++ b/.github/workflows/run-cache-result-action.yml
@@ -1,8 +1,11 @@
 name: run-cache-result-action
 on: push
 
-# edge should point to master or a branch commit to verify
+# tag: `edge` should point to master or a branch commit to verify
 # that a change is valid before merging.
+
+# To update edge to the current commit, use:
+# $ git tag -f edge HEAD; git push -f origin edge
 
 jobs:
   check-sha-result:

--- a/.github/workflows/run-cache-result-action.yml
+++ b/.github/workflows/run-cache-result-action.yml
@@ -1,6 +1,9 @@
 name: run-cache-result-action
 on: push
 
+# edge should point to master or a branch commit to verify
+# that a change is valid before merging.
+
 jobs:
   check-sha-result:
     runs-on: ubuntu-latest
@@ -9,10 +12,10 @@ jobs:
       optional-result: ${{ steps.restore-secondary-cache.outputs.result }}
     steps:
       - id: restore-cache
-        uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
+        uses: parallel-markets/cache-result-action@edge
 
       - id: restore-secondary-cache
-        uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
+        uses: parallel-markets/cache-result-action@edge
         with:
           cache-group: optional
 
@@ -20,7 +23,7 @@ jobs:
     needs: check-sha-result
     runs-on: ubuntu-latest
     steps:
-      - uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
+      - uses: parallel-markets/cache-result-action@edge
         with:
           result: success
 
@@ -28,7 +31,7 @@ jobs:
     needs: check-sha-result
     runs-on: ubuntu-latest
     steps:
-      - uses: parallel-markets/cache-result-action@a1e2c3ccc1be6464c4d571ff2932d6b6c9ae3e3d
+      - uses: parallel-markets/cache-result-action@edge
         with:
           result: success
           cache-group: optional

--- a/README.md
+++ b/README.md
@@ -63,3 +63,6 @@ jobs:
 When opening a PR, update the `edge` tag to ensure that `.github/workflows/run-cache-result-action.yml` exercises any changes prior to merging. Additionally, update the version in `package.json` according to semver as appropriate.
 
 After merging, update version tags (e.g., `v1` and `v1.0.1`) according to semver, as appropriate. As a courtesy, also update `edge` to point to the latest commit.
+
+To update edge to the current commit, use:
+> $ git tag -f edge HEAD && git push -f origin edge

--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ jobs:
         with:
           result: success
 ```
+
+## Development
+
+When opening a PR, update the `edge` tag to ensure that `.github/workflows/run-cache-result-action.yml` exercises any changes prior to merging. Additionally, update the version in `package.json` according to semver as appropriate.
+
+After merging, update version tags (e.g., `v1` and `v1.0.1`) according to semver, as appropriate. As a courtesy, also update `edge` to point to the latest commit.

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: last-run
-        uses: parallel-markets/cache-result-action@v1.0.0
+        uses: parallel-markets/cache-result-action@v2
 
       - run: make test
         if: steps.last-run.outputs.result != 'success'
 
-      - uses: parallel-markets/cache-result-action@v1.0.0
+      - uses: parallel-markets/cache-result-action@v2
         with:
           result: success
 ```
@@ -45,7 +45,7 @@ jobs:
       prev-result: ${{ steps.last-run.outputs.result }}
     steps:
       - id: last-run
-        uses: parallel-markets/cache-result-action@v1.0.0
+        uses: parallel-markets/cache-result-action@v2
 
   test:
     runs-on: ubuntu-latest
@@ -53,16 +53,19 @@ jobs:
     if: needs.fetch-prev-result.outputs.prev_result != 'success'
     steps:
       - run: make test
-      - uses: parallel-markets/cache-result-action@v1.0.0
+      - uses: parallel-markets/cache-result-action@v2
         with:
           result: success
 ```
 
 ## Development
 
-When opening a PR, update the `edge` tag to ensure that `.github/workflows/run-cache-result-action.yml` exercises any changes prior to merging. Additionally, update the version in `package.json` according to semver as appropriate.
+When opening a PR, update the `edge` tag to ensure that `.github/workflows/run-cache-result-action.yml` exercises any changes prior to merging. Additionally, update the version in `package.json` according to semver as appropriate. If the change warrants a major release, update the [examples above](#examples).
 
-After merging, update version tags (e.g., `v1` and `v1.0.1`) according to semver, as appropriate. As a courtesy, also update `edge` to point to the latest commit.
+### Releasing
+
+After merging, update version tags according to semver, as appropriate. As a courtesy, also update `edge` to point to the latest commit.
 
 To update edge to the current commit, use:
-> $ git tag -f edge HEAD && git push -f origin edge
+
+    $ git tag -f edge HEAD && git push -f origin edge

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   result:
     description: 'Most recent result'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-result-action",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "description": "Github Action for storing results from previous runs by SHA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates cache-result-action to use Node 20. After this merges, I will tag the new commit as `v2` and `v2.0.0`. We will then want to update our usage(s) in other repos to point to `@v2`.

From Github: 

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: parallel-markets/cache-result-action@v1.0.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
>
> Node 16 has reached its end of life, prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. We will actively monitor the migration's progress and gather community feedback before finalizing the transition date. Starting October 23rd, workflows containing actions running on Node 16 will display a warning to alert users about the upcoming migration.



