### PR TITLE
Update action.yml to use node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   result:
     description: 'Most recent result'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cache-result-action",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cache-result-action",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-result-action",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Github Action for storing results from previous runs by SHA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previous PR updated `workflows` but not `action.yml` so we continued seeing node 20 warnings.

https://github.com/parallel-markets/cache-result-action/actions/runs/23316286012/job/67816538077